### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ else:
 Currently, the PrintMT() does an inorder traversal and prints the values accordingly. The per- and post-order traversals should also be implemented.
 
 ### Handling file/folder adding and deleting 
-When two merkle trees are compared, other than modification/updation of file/folder, the comparision algorithm should also look out for the new added or deleted files. The following will cover all the cases.
+When two merkle trees are compared, other than modification/updation of file/folder, the comparison algorithm should also look out for the new added or deleted files. The following will cover all the cases.
 
 ```
 for hashes in treeA


### PR DESCRIPTION
@sangeeths, I've corrected a typographical error in the documentation of the [merkle-tree](https://github.com/sangeeths/merkle-tree) project. Specifically, I've changed comparision to comparison. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
